### PR TITLE
Update to support ivory-google-map refactor regarding psr/http* packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,27 +16,18 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.3]
+                php: [8.2]
                 stability: [ prefer-stable ]
-                symfony-version: [ '7.0.*' ]
+                symfony-version: [ '7.3' ]
                 include:
-                  - php: '8.1'
-                    symfony-version: 6.4.*
+                  - symfony-version: 6.4
+                    php: '8.1'
                     stability: prefer-lowest
-                  - php: '8.1'
-                    symfony-version: 6.4.*
+                  - symfony-version: 6.4
+                    php: '8.1'
                     stability: prefer-stable
-                  - php: '8.2'
-                    symfony-version: 6.4.*
-                    stability: prefer-stable
-                  - php: '8.2'
-                    symfony-version: 7.0.*
-                    stability: prefer-stable
-                  - php: '8.3'
-                    symfony-version: 7.0.*
-                    stability: prefer-stable
-                  - php: '8.4'
-                    symfony-version: 7.0.*
+                  - symfony-version: 7.3
+                    php: '8.4'
                     stability: prefer-stable
 
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,24 +11,21 @@ jobs:
     tests:
         runs-on: ubuntu-latest
 
-        name: PHP ${{ matrix.php }} - ${{ matrix.symfony-version }} - ${{ matrix.stability }}
+        name: PHP ${{ matrix.php }} - ${{ matrix.symfony }} - ${{ matrix.deps }}
 
         strategy:
             fail-fast: false
             matrix:
-                php: [8.2]
-                stability: [ prefer-stable ]
-                symfony-version: [ '7.3' ]
+                php: [ 8.2, 8.3, 8.4, 8.5 ]
+                deps: [ locked ]
+                symfony: [ '6.4.*', '7.3.*' ]
                 include:
-                  - symfony-version: 6.4
-                    php: '8.1'
-                    stability: prefer-lowest
-                  - symfony-version: 6.4
-                    php: '8.1'
-                    stability: prefer-stable
-                  - symfony-version: 7.3
-                    php: '8.4'
-                    stability: prefer-stable
+                    - symfony: '6.4.*'
+                      php: '8.1'
+                      deps: lowest
+                    - symfony: '7.4.*'
+                      php: '8.5'
+                      deps: highest
 
         env:
             APP_ENV: test
@@ -42,32 +39,22 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"
+                    ini-values: zend.exception_ignore_args=false
                     extensions: intl
-                    tools: symfony
+                    tools: symfony, flex
                     coverage: none
 
             -
-                name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                name: Configure composer
+                if: "${{ matrix.deps == 'highest' }}"
+                run: composer config minimum-stability dev
 
             -
-                name: Cache Composer
-                uses: actions/cache@v4
+                name: Composer install
+                uses: ramsey/composer-install@v3
                 with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php-${{ matrix.php }}-composer-
-
-            -
-                name: Install PHP dependencies
-                env:
-                      SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
-                run: |
-                      composer global config --no-plugins allow-plugins.symfony/flex true
-                      composer global require --no-progress --no-scripts --no-plugins symfony/flex
-                      composer update --no-interaction --prefer-dist
+                    dependency-versions: '${{ matrix.deps }}'
+                    composer-options: --no-interaction --prefer-dist
 
             -
                 name: Run analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,11 @@ jobs:
             matrix:
                 php: [ 8.2, 8.3, 8.4, 8.5 ]
                 deps: [ locked ]
-                symfony: [ '6.4.*', '7.3.*' ]
+                symfony: [ '6.4.*', '7.4.*', '8.0.*' ]
                 include:
                     - symfony: '6.4.*'
                       php: '8.1'
                       deps: lowest
-                    - symfony: '7.4.*'
-                      php: '8.5'
-                      deps: highest
 
         env:
             APP_ENV: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 7.0.0 (xxx)
 
- * updated to support `ivory/google-map:7.0`, full PSR-17 and PSR-18 compatibility
+ * Updated to support `ivory/google-map:7.0`, full PSR-17 and PSR-18 compatibility
+ * Drop support for Symfony 7.0, 7.1, 7.2
 
 ### 3.0.4 (2020-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 7.0.0 (xxx)
+
+ * updated to support `ivory/google-map:7.0`, full PSR-17 and PSR-18 compatibility
+
 ### 3.0.4 (2020-06-13)
 
  * updated documentation

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -86,7 +86,7 @@ class Configuration implements ConfigurationInterface
                 ->isRequired()
                 ->cannotBeEmpty()
                 ->end()
-                ->scalarNode('message_factory')
+                ->scalarNode('request_factory')
                 ->isRequired()
                 ->cannotBeEmpty()
                 ->end()

--- a/DependencyInjection/IvoryGoogleMapExtension.php
+++ b/DependencyInjection/IvoryGoogleMapExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
@@ -31,7 +31,7 @@ class IvoryGoogleMapExtension extends ConfigurableExtension
      */
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         $resources = [
             'form',
@@ -44,7 +44,7 @@ class IvoryGoogleMapExtension extends ConfigurableExtension
         ];
 
         foreach ($resources as $resource) {
-            $loader->load($resource . '.xml');
+            $loader->load($resource . '.php');
         }
 
         $this->loadMapConfig($mergedConfig['map'], $container);
@@ -135,7 +135,7 @@ class IvoryGoogleMapExtension extends ConfigurableExtension
                          $http = true
     ): void
     {
-        $loader->load('service/' . $service . '.xml');
+        $loader->load('service/' . $service . '.php');
         $definition = $container->getDefinition($serviceName = 'ivory.google_map.' . $service);
 
         if ($http) {

--- a/DependencyInjection/IvoryGoogleMapExtension.php
+++ b/DependencyInjection/IvoryGoogleMapExtension.php
@@ -141,7 +141,7 @@ class IvoryGoogleMapExtension extends ConfigurableExtension
         if ($http) {
             $definition
                 ->addArgument(new Reference($config['client']))
-                ->addArgument(new Reference($config['message_factory']));
+                ->addArgument(new Reference($config['request_factory']));
         }
 
         if ($http && isset($config['format'])) {

--- a/Resources/config/form.php
+++ b/Resources/config/form.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.form.type.place_autocomplete', \Ivory\GoogleMapBundle\Form\Type\PlaceAutocompleteType::class)
+        ->tag('form.type');
+};

--- a/Resources/config/helper/collector.php
+++ b/Resources/config/helper/collector.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.helper.collector.base.bound', \Ivory\GoogleMap\Helper\Collector\Base\BoundCollector::class)
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.ground_overlay'),
+            service('ivory.google_map.helper.collector.overlay.rectangle'),
+        ]);
+
+    $services->set('ivory.google_map.helper.collector.base.coordinate', \Ivory\GoogleMap\Helper\Collector\Base\CoordinateCollector::class)
+        ->args([
+            service('ivory.google_map.helper.collector.base.bound'),
+            service('ivory.google_map.helper.collector.overlay.circle'),
+            service('ivory.google_map.helper.collector.overlay.info_window'),
+            service('ivory.google_map.helper.collector.overlay.marker'),
+            service('ivory.google_map.helper.collector.overlay.polygon'),
+            service('ivory.google_map.helper.collector.overlay.polyline'),
+            service('ivory.google_map.helper.collector.layer.heatmap'),
+        ]);
+
+    $services->set('ivory.google_map.helper.collector.base.point', \Ivory\GoogleMap\Helper\Collector\Base\PointCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.marker')]);
+
+    $services->set('ivory.google_map.helper.collector.base.size', \Ivory\GoogleMap\Helper\Collector\Base\SizeCollector::class)
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.info_window'),
+            service('ivory.google_map.helper.collector.overlay.icon'),
+        ]);
+
+    $services->set('ivory.google_map.helper.collector.control.custom', \Ivory\GoogleMap\Helper\Collector\Control\CustomControlCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.event.dom_event', \Ivory\GoogleMap\Helper\Collector\Event\DomEventCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.event.dom_event_once', \Ivory\GoogleMap\Helper\Collector\Event\DomEventOnceCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.event.event', \Ivory\GoogleMap\Helper\Collector\Event\EventCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.event.event_once', \Ivory\GoogleMap\Helper\Collector\Event\EventOnceCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.layer.geo_json', \Ivory\GoogleMap\Helper\Collector\Layer\GeoJsonLayerCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.layer.heatmap', \Ivory\GoogleMap\Helper\Collector\Layer\HeatmapLayerCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.layer.kml', \Ivory\GoogleMap\Helper\Collector\Layer\KmlLayerCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.circle', \Ivory\GoogleMap\Helper\Collector\Overlay\CircleCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.encoded_polyline', \Ivory\GoogleMap\Helper\Collector\Overlay\EncodedPolylineCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.extendable', \Ivory\GoogleMap\Helper\Collector\Overlay\ExtendableCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.ground_overlay', \Ivory\GoogleMap\Helper\Collector\Overlay\GroundOverlayCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.icon', \Ivory\GoogleMap\Helper\Collector\Overlay\IconCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.marker')]);
+
+    $services->set('ivory.google_map.helper.collector.overlay.icon_sequence', \Ivory\GoogleMap\Helper\Collector\Overlay\IconSequenceCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.polyline')]);
+
+    $services->set('ivory.google_map.helper.collector.overlay.info_box', \Ivory\GoogleMap\Helper\Collector\Overlay\InfoBoxCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.marker')]);
+
+    $services->set('ivory.google_map.helper.collector.overlay.info_window', \Ivory\GoogleMap\Helper\Collector\Overlay\InfoWindowCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.marker')]);
+
+    $services->set('ivory.google_map.helper.collector.overlay.info_window.default', \Ivory\GoogleMap\Helper\Collector\Overlay\DefaultInfoWindowCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.marker')]);
+
+    $services->set('ivory.google_map.helper.collector.overlay.marker', \Ivory\GoogleMap\Helper\Collector\Overlay\MarkerCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.marker_shape', \Ivory\GoogleMap\Helper\Collector\Overlay\MarkerShapeCollector::class)
+        ->args([service('ivory.google_map.helper.collector.overlay.marker')]);
+
+    $services->set('ivory.google_map.helper.collector.overlay.polygon', \Ivory\GoogleMap\Helper\Collector\Overlay\PolygonCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.polyline', \Ivory\GoogleMap\Helper\Collector\Overlay\PolylineCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.rectangle', \Ivory\GoogleMap\Helper\Collector\Overlay\RectangleCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.overlay.symbol', \Ivory\GoogleMap\Helper\Collector\Overlay\SymbolCollector::class)
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.marker'),
+            service('ivory.google_map.helper.collector.overlay.icon_sequence'),
+        ]);
+
+    $services->set('ivory.google_map.helper.collector.place.autocomplete.base.bound', \Ivory\GoogleMap\Helper\Collector\Place\Base\AutocompleteBoundCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.place.autocomplete.base.coordinate', \Ivory\GoogleMap\Helper\Collector\Place\Base\AutocompleteCoordinateCollector::class)
+        ->args([service('ivory.google_map.helper.collector.place.autocomplete.base.bound')]);
+
+    $services->set('ivory.google_map.helper.collector.place.autocomplete.event.dom_event', \Ivory\GoogleMap\Helper\Collector\Place\Event\AutocompleteDomEventCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.place.autocomplete.event.dom_event_once', \Ivory\GoogleMap\Helper\Collector\Place\Event\AutocompleteDomEventOnceCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.place.autocomplete.event.event', \Ivory\GoogleMap\Helper\Collector\Place\Event\AutocompleteEventCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.place.autocomplete.event.event_once', \Ivory\GoogleMap\Helper\Collector\Place\Event\AutocompleteEventOnceCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.static.encoded_polyline', \Ivory\GoogleMap\Helper\Collector\Image\EncodedPolylineCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.static.extendable', \Ivory\GoogleMap\Helper\Collector\Image\ExtendableCollector::class);
+
+    $services->set('ivory.google_map.helper.collector.static.marker', \Ivory\GoogleMap\Helper\Collector\Image\MarkerCollector::class)
+        ->args([service('ivory.google_map.helper.renderer.static.overlay.marker.style')]);
+
+    $services->set('ivory.google_map.helper.collector.static.polyline', \Ivory\GoogleMap\Helper\Collector\Image\PolylineCollector::class);
+};

--- a/Resources/config/helper/helper.php
+++ b/Resources/config/helper/helper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.helper.api', \Ivory\GoogleMap\Helper\ApiHelper::class)
+        ->args([service('ivory.google_map.helper.api.event_dispatcher')]);
+
+    $services->set('ivory.google_map.helper.api.event_dispatcher', \Symfony\Component\EventDispatcher\EventDispatcher::class);
+
+    $services->set('ivory.google_map.helper.map', \Ivory\GoogleMap\Helper\MapHelper::class)
+        ->args([service('ivory.google_map.helper.map.event_dispatcher')]);
+
+    $services->set('ivory.google_map.helper.map.event_dispatcher', \Symfony\Component\EventDispatcher\EventDispatcher::class);
+
+    $services->set('ivory.google_map.helper.map.static', \Ivory\GoogleMap\Helper\StaticMapHelper::class)
+        ->args([service('ivory.google_map.helper.map.static.event_dispatcher')]);
+
+    $services->set('ivory.google_map.helper.map.static.event_dispatcher', \Symfony\Component\EventDispatcher\EventDispatcher::class);
+
+    $services->set('ivory.google_map.helper.place_autocomplete', \Ivory\GoogleMap\Helper\PlaceAutocompleteHelper::class)
+        ->args([service('ivory.google_map.helper.place_autocomplete.event_dispatcher')]);
+
+    $services->set('ivory.google_map.helper.place_autocomplete.event_dispatcher', \Symfony\Component\EventDispatcher\EventDispatcher::class);
+};

--- a/Resources/config/helper/renderer.php
+++ b/Resources/config/helper/renderer.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.helper.renderer.abstract', \Ivory\GoogleMap\Helper\Renderer\AbstractRenderer::class)
+        ->abstract()
+        ->args([service('ivory.google_map.helper.formatter')]);
+
+    $services->set('ivory.google_map.helper.renderer.json', \Ivory\GoogleMap\Helper\Renderer\AbstractJsonRenderer::class)
+        ->abstract()
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([service('ivory.google_map.helper.json_builder')]);
+
+    $services->set('ivory.google_map.helper.renderer.api', \Ivory\GoogleMap\Helper\Renderer\ApiRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([
+            service('ivory.google_map.helper.renderer.api_init'),
+            service('ivory.google_map.helper.renderer.loader'),
+            service('ivory.google_map.helper.renderer.utility.requirement_loader'),
+            service('ivory.google_map.helper.renderer.utility.source'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.api_init', \Ivory\GoogleMap\Helper\Renderer\ApiInitRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.base.bound', \Ivory\GoogleMap\Helper\Renderer\Base\BoundRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.base.coordinate', \Ivory\GoogleMap\Helper\Renderer\Base\CoordinateRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.base.point', \Ivory\GoogleMap\Helper\Renderer\Base\PointRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.base.size', \Ivory\GoogleMap\Helper\Renderer\Base\SizeRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.control.manager', \Ivory\GoogleMap\Helper\Renderer\Control\ControlManagerRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.control.position', \Ivory\GoogleMap\Helper\Renderer\Control\ControlPositionRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.control.custom', \Ivory\GoogleMap\Helper\Renderer\Control\CustomControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([service('ivory.google_map.helper.renderer.control.position')]);
+
+    $services->set('ivory.google_map.helper.renderer.control.fullscreen', \Ivory\GoogleMap\Helper\Renderer\Control\FullscreenControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.control.position')])
+        ->tag('ivory.google_map.helper.renderer.control');
+
+    $services->set('ivory.google_map.helper.renderer.control.map_type', \Ivory\GoogleMap\Helper\Renderer\Control\MapTypeControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([
+            service('ivory.google_map.helper.renderer.map_type_id'),
+            service('ivory.google_map.helper.renderer.control.position'),
+            service('ivory.google_map.helper.renderer.control.map_type_style'),
+        ])
+        ->tag('ivory.google_map.helper.renderer.control');
+
+    $services->set('ivory.google_map.helper.renderer.control.map_type_style', \Ivory\GoogleMap\Helper\Renderer\Control\MapTypeControlStyleRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.control.rotate', \Ivory\GoogleMap\Helper\Renderer\Control\RotateControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.control.position')])
+        ->tag('ivory.google_map.helper.renderer.control');
+
+    $services->set('ivory.google_map.helper.renderer.control.scale', \Ivory\GoogleMap\Helper\Renderer\Control\ScaleControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([
+            service('ivory.google_map.helper.renderer.control.position'),
+            service('ivory.google_map.helper.renderer.control.scale_style'),
+        ])
+        ->tag('ivory.google_map.helper.renderer.control');
+
+    $services->set('ivory.google_map.helper.renderer.control.scale_style', \Ivory\GoogleMap\Helper\Renderer\Control\ScaleControlStyleRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.control.street_view', \Ivory\GoogleMap\Helper\Renderer\Control\StreetViewControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.control.position')])
+        ->tag('ivory.google_map.helper.renderer.control');
+
+    $services->set('ivory.google_map.helper.renderer.control.zoom', \Ivory\GoogleMap\Helper\Renderer\Control\ZoomControlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([
+            service('ivory.google_map.helper.renderer.control.position'),
+            service('ivory.google_map.helper.renderer.control.zoom_style'),
+        ])
+        ->tag('ivory.google_map.helper.renderer.control');
+
+    $services->set('ivory.google_map.helper.renderer.control.zoom_style', \Ivory\GoogleMap\Helper\Renderer\Control\ZoomControlStyleRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.event.dom_event', \Ivory\GoogleMap\Helper\Renderer\Event\DomEventRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.event.dom_event_once', \Ivory\GoogleMap\Helper\Renderer\Event\DomEventOnceRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.event.event', \Ivory\GoogleMap\Helper\Renderer\Event\EventRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.event.event_once', \Ivory\GoogleMap\Helper\Renderer\Event\EventOnceRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.geometry.encoding', \Ivory\GoogleMap\Helper\Renderer\Geometry\EncodingRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.html.tag', \Ivory\GoogleMap\Helper\Renderer\Html\TagRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.html.javascript_tag', \Ivory\GoogleMap\Helper\Renderer\Html\JavascriptTagRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([service('ivory.google_map.helper.renderer.html.tag')]);
+
+    $services->set('ivory.google_map.helper.renderer.html.stylesheet', \Ivory\GoogleMap\Helper\Renderer\Html\StylesheetRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.html.stylesheet_tag', \Ivory\GoogleMap\Helper\Renderer\Html\StylesheetTagRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([
+            service('ivory.google_map.helper.renderer.html.tag'),
+            service('ivory.google_map.helper.renderer.html.stylesheet'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.layer.geo_json', \Ivory\GoogleMap\Helper\Renderer\Layer\GeoJsonLayerRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.layer.heatmap', \Ivory\GoogleMap\Helper\Renderer\Layer\HeatmapLayerRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.layer.kml', \Ivory\GoogleMap\Helper\Renderer\Layer\KmlLayerRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.loader', \Ivory\GoogleMap\Helper\Renderer\LoaderRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.map', \Ivory\GoogleMap\Helper\Renderer\MapRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([
+            service('ivory.google_map.helper.renderer.map_type_id'),
+            service('ivory.google_map.helper.renderer.control.manager'),
+            service('ivory.google_map.helper.renderer.utility.requirement'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.map_bound', \Ivory\GoogleMap\Helper\Renderer\MapBoundRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.map_center', \Ivory\GoogleMap\Helper\Renderer\MapCenterRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.map_container', \Ivory\GoogleMap\Helper\Renderer\MapContainerRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.map_html', \Ivory\GoogleMap\Helper\Renderer\MapHtmlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([
+            service('ivory.google_map.helper.renderer.html.tag'),
+            service('ivory.google_map.helper.renderer.html.stylesheet'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.map_type_id', \Ivory\GoogleMap\Helper\Renderer\MapTypeIdRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.animation', \Ivory\GoogleMap\Helper\Renderer\Overlay\AnimationRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.circle', \Ivory\GoogleMap\Helper\Renderer\Overlay\CircleRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.encoded_polyline', \Ivory\GoogleMap\Helper\Renderer\Overlay\EncodedPolylineRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.geometry.encoding')]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.extendable', \Ivory\GoogleMap\Helper\Renderer\Overlay\Extendable\ExtendableRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.extendable.default_viewport', \Ivory\GoogleMap\Helper\Renderer\Overlay\Extendable\DefaultViewportExtendableRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Layer\KmlLayer::class]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.extendable.heatmap_layer', \Ivory\GoogleMap\Helper\Renderer\Overlay\Extendable\HeatmapLayerExtendableRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Layer\HeatmapLayer::class]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.extendable.path', \Ivory\GoogleMap\Helper\Renderer\Overlay\Extendable\PathExtendableRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\EncodedPolyline::class])
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\Polyline::class])
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\Polygon::class]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.extendable.position', \Ivory\GoogleMap\Helper\Renderer\Overlay\Extendable\PositionExtendableRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\InfoWindow::class])
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\Marker::class]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.extendable.bounds', \Ivory\GoogleMap\Helper\Renderer\Overlay\Extendable\BoundsExtendableRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\Circle::class])
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\GroundOverlay::class])
+        ->tag('ivory.google_map.helper.renderer.extendable', ['class' => \Ivory\GoogleMap\Overlay\Rectangle::class]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.ground_overlay', \Ivory\GoogleMap\Helper\Renderer\Overlay\GroundOverlayRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.icon', \Ivory\GoogleMap\Helper\Renderer\Overlay\IconRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.icon_sequence', \Ivory\GoogleMap\Helper\Renderer\Overlay\IconSequenceRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.info_box', \Ivory\GoogleMap\Helper\Renderer\Overlay\InfoBoxRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.utility.requirement')]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.info_window.close', \Ivory\GoogleMap\Helper\Renderer\Overlay\InfoWindowCloseRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.info_window.open', \Ivory\GoogleMap\Helper\Renderer\Overlay\InfoWindowOpenRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.info_window.default', \Ivory\GoogleMap\Helper\Renderer\Overlay\DefaultInfoWindowRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.marker', \Ivory\GoogleMap\Helper\Renderer\Overlay\MarkerRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.overlay.animation')]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.marker_clusterer', \Ivory\GoogleMap\Helper\Renderer\Overlay\MarkerClustererRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.utility.requirement')]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.marker_shape', \Ivory\GoogleMap\Helper\Renderer\Overlay\MarkerShapeRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.polygon', \Ivory\GoogleMap\Helper\Renderer\Overlay\PolygonRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.polyline', \Ivory\GoogleMap\Helper\Renderer\Overlay\PolylineRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.rectangle', \Ivory\GoogleMap\Helper\Renderer\Overlay\RectangleRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json');
+
+    $services->set('ivory.google_map.helper.renderer.overlay.symbol', \Ivory\GoogleMap\Helper\Renderer\Overlay\SymbolRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.overlay.symbol_path')]);
+
+    $services->set('ivory.google_map.helper.renderer.overlay.symbol_path', \Ivory\GoogleMap\Helper\Renderer\Overlay\SymbolPathRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.place.autocomplete', \Ivory\GoogleMap\Helper\Renderer\Place\AutocompleteRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.utility.requirement')]);
+
+    $services->set('ivory.google_map.helper.renderer.place.autocomplete_container', \Ivory\GoogleMap\Helper\Renderer\Place\AutocompleteContainerRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.json')
+        ->args([service('ivory.google_map.helper.renderer.html.tag')]);
+
+    $services->set('ivory.google_map.helper.renderer.place.autocomplete_html', \Ivory\GoogleMap\Helper\Renderer\Place\AutocompleteHtmlRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract')
+        ->args([service('ivory.google_map.helper.renderer.html.tag')]);
+
+    $services->set('ivory.google_map.helper.renderer.static.base.coordinate', \Ivory\GoogleMap\Helper\Renderer\Image\Base\CoordinateRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.static.base.point', \Ivory\GoogleMap\Helper\Renderer\Image\Base\PointRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.encoded_polyline', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\EncodedPolylineRenderer::class)
+        ->args([
+            service('ivory.google_map.helper.renderer.static.overlay.encoded_polyline.style'),
+            service('ivory.google_map.helper.renderer.static.overlay.encoded_polyline.value'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.encoded_polyline.style', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\EncodedPolylineStyleRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.encoded_polyline.value', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\EncodedPolylineValueRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.extendable', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\ExtendableRenderer::class)
+        ->args([
+            service('ivory.google_map.helper.renderer.static.base.coordinate'),
+            service('ivory.google_map.helper.renderer.static.overlay.marker.location'),
+            service('ivory.google_map.helper.renderer.static.overlay.polyline.location'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.marker', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\MarkerRenderer::class)
+        ->args([
+            service('ivory.google_map.helper.renderer.static.overlay.marker.style'),
+            service('ivory.google_map.helper.renderer.static.overlay.marker.location'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.marker.style', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\MarkerStyleRenderer::class)
+        ->args([service('ivory.google_map.helper.renderer.static.base.point')]);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.marker.location', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\MarkerLocationRenderer::class)
+        ->args([service('ivory.google_map.helper.renderer.static.base.coordinate')]);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.polyline', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\PolylineRenderer::class)
+        ->args([
+            service('ivory.google_map.helper.renderer.static.overlay.polyline.style'),
+            service('ivory.google_map.helper.renderer.static.overlay.polyline.location'),
+        ]);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.polyline.style', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\PolylineStyleRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.static.overlay.polyline.location', \Ivory\GoogleMap\Helper\Renderer\Image\Overlay\PolylineLocationRenderer::class)
+        ->args([service('ivory.google_map.helper.renderer.static.base.coordinate')]);
+
+    $services->set('ivory.google_map.helper.renderer.static.size', \Ivory\GoogleMap\Helper\Renderer\Image\SizeRenderer::class);
+
+    $services->set('ivory.google_map.helper.renderer.utility.callback', \Ivory\GoogleMap\Helper\Renderer\Utility\CallbackRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.utility.object_to_array', \Ivory\GoogleMap\Helper\Renderer\Utility\ObjectToArrayRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.utility.requirement_loader', \Ivory\GoogleMap\Helper\Renderer\Utility\RequirementLoaderRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.utility.requirement', \Ivory\GoogleMap\Helper\Renderer\Utility\RequirementRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+
+    $services->set('ivory.google_map.helper.renderer.utility.source', \Ivory\GoogleMap\Helper\Renderer\Utility\SourceRenderer::class)
+        ->parent('ivory.google_map.helper.renderer.abstract');
+};

--- a/Resources/config/helper/subscriber.php
+++ b/Resources/config/helper/subscriber.php
@@ -1,0 +1,469 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.helper.subscriber.abstract', \Ivory\GoogleMap\Helper\Subscriber\AbstractSubscriber::class)
+        ->abstract()
+        ->args([service('ivory.google_map.helper.formatter')]);
+
+    $services->set('ivory.google_map.helper.subscriber.api_javascript', \Ivory\GoogleMap\Helper\Subscriber\ApiJavascriptSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.renderer.api'),
+            service('ivory.google_map.helper.renderer.html.javascript_tag'),
+        ])
+        ->tag('ivory.google_map.helper.api.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.base', \Ivory\GoogleMap\Helper\Subscriber\Base\BaseSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.base.bound', \Ivory\GoogleMap\Helper\Subscriber\Base\BoundSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.base.bound'),
+            service('ivory.google_map.helper.renderer.base.bound'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.base.coordinate', \Ivory\GoogleMap\Helper\Subscriber\Base\CoordinateSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.base.coordinate'),
+            service('ivory.google_map.helper.renderer.base.coordinate'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.base.point', \Ivory\GoogleMap\Helper\Subscriber\Base\PointSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.base.point'),
+            service('ivory.google_map.helper.renderer.base.point'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.base.size', \Ivory\GoogleMap\Helper\Subscriber\Base\SizeSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.base.size'),
+            service('ivory.google_map.helper.renderer.base.size'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.control', \Ivory\GoogleMap\Helper\Subscriber\Control\ControlSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.control.custom', \Ivory\GoogleMap\Helper\Subscriber\Control\CustomControlSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.control.custom'),
+            service('ivory.google_map.helper.renderer.control.custom'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.event', \Ivory\GoogleMap\Helper\Subscriber\Event\EventSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.event.dom_event', \Ivory\GoogleMap\Helper\Subscriber\Event\DomEventSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.event.dom_event'),
+            service('ivory.google_map.helper.renderer.event.dom_event'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.event.dom_event_once', \Ivory\GoogleMap\Helper\Subscriber\Event\DomEventOnceSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.event.dom_event_once'),
+            service('ivory.google_map.helper.renderer.event.dom_event_once'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.event.event', \Ivory\GoogleMap\Helper\Subscriber\Event\SimpleEventSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.event.event'),
+            service('ivory.google_map.helper.renderer.event.event'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.event.event_once', \Ivory\GoogleMap\Helper\Subscriber\Event\EventOnceSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.event.event_once'),
+            service('ivory.google_map.helper.renderer.event.event_once'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.layer', \Ivory\GoogleMap\Helper\Subscriber\Layer\LayerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.layer.geo_json', \Ivory\GoogleMap\Helper\Subscriber\Layer\GeoJsonLayerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.layer.geo_json'),
+            service('ivory.google_map.helper.renderer.layer.geo_json'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.layer.heatmap', \Ivory\GoogleMap\Helper\Subscriber\Layer\HeatmapLayerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.layer.heatmap'),
+            service('ivory.google_map.helper.renderer.layer.heatmap'),
+        ])
+        ->tag('ivory.google_map.helper.api.subscriber')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.layer.kml', \Ivory\GoogleMap\Helper\Subscriber\Layer\KmlLayerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.layer.kml'),
+            service('ivory.google_map.helper.renderer.layer.kml'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map', \Ivory\GoogleMap\Helper\Subscriber\MapSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.map')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_bound', \Ivory\GoogleMap\Helper\Subscriber\MapBoundSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.map_bound')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_center', \Ivory\GoogleMap\Helper\Subscriber\MapCenterSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.map_center')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_container', \Ivory\GoogleMap\Helper\Subscriber\MapContainerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.map_container')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_html', \Ivory\GoogleMap\Helper\Subscriber\MapHtmlSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.map_html')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_init', \Ivory\GoogleMap\Helper\Subscriber\MapInitSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_javascript', \Ivory\GoogleMap\Helper\Subscriber\MapJavascriptSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.renderer.map'),
+            service('ivory.google_map.helper.renderer.utility.callback'),
+            service('ivory.google_map.helper.renderer.html.javascript_tag'),
+        ])
+        ->tag('ivory.google_map.helper.api.subscriber')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.map_stylehseet', \Ivory\GoogleMap\Helper\Subscriber\MapStylesheetSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.html.stylesheet_tag')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay', \Ivory\GoogleMap\Helper\Subscriber\Overlay\OverlaySubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.circle', \Ivory\GoogleMap\Helper\Subscriber\Overlay\CircleSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.circle'),
+            service('ivory.google_map.helper.renderer.overlay.circle'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.encoded_polyline', \Ivory\GoogleMap\Helper\Subscriber\Overlay\EncodedPolylineSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.encoded_polyline'),
+            service('ivory.google_map.helper.renderer.overlay.encoded_polyline'),
+        ])
+        ->tag('ivory.google_map.helper.api.subscriber')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.extendable', \Ivory\GoogleMap\Helper\Subscriber\Overlay\ExtendableSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.extendable'),
+            service('ivory.google_map.helper.renderer.overlay.extendable'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.ground_overlay', \Ivory\GoogleMap\Helper\Subscriber\Overlay\GroundOverlaySubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.ground_overlay'),
+            service('ivory.google_map.helper.renderer.overlay.ground_overlay'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.icon', \Ivory\GoogleMap\Helper\Subscriber\Overlay\IconSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.icon'),
+            service('ivory.google_map.helper.renderer.overlay.icon'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.icon_sequence', \Ivory\GoogleMap\Helper\Subscriber\Overlay\IconSequenceSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.icon_sequence'),
+            service('ivory.google_map.helper.renderer.overlay.icon_sequence'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.info_box', \Ivory\GoogleMap\Helper\Subscriber\Overlay\InfoBoxSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.info_box'),
+            service('ivory.google_map.helper.renderer.overlay.info_box'),
+        ])
+        ->tag('ivory.google_map.helper.api.subscriber')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.info_window.close', \Ivory\GoogleMap\Helper\Subscriber\Overlay\InfoWindowCloseSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.info_window'),
+            service('ivory.google_map.helper.renderer.overlay.info_window.close'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.info_window.open', \Ivory\GoogleMap\Helper\Subscriber\Overlay\InfoWindowOpenSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.info_window'),
+            service('ivory.google_map.helper.renderer.overlay.info_window.open'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.info_window.default', \Ivory\GoogleMap\Helper\Subscriber\Overlay\DefaultInfoWindowSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.info_window.default'),
+            service('ivory.google_map.helper.renderer.overlay.info_window.default'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.marker', \Ivory\GoogleMap\Helper\Subscriber\Overlay\MarkerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.marker'),
+            service('ivory.google_map.helper.renderer.overlay.marker'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.marker_clusterer', \Ivory\GoogleMap\Helper\Subscriber\Overlay\MarkerClustererSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.overlay.marker_clusterer')])
+        ->tag('ivory.google_map.helper.api.subscriber')
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.marker_shape', \Ivory\GoogleMap\Helper\Subscriber\Overlay\MarkerShapeSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.marker_shape'),
+            service('ivory.google_map.helper.renderer.overlay.marker_shape'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.marker.info_window.open', \Ivory\GoogleMap\Helper\Subscriber\Overlay\MarkerInfoWindowOpenSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.marker'),
+            service('ivory.google_map.helper.renderer.overlay.info_window.open'),
+            service('ivory.google_map.helper.renderer.event.event'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.polygon', \Ivory\GoogleMap\Helper\Subscriber\Overlay\PolygonSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.polygon'),
+            service('ivory.google_map.helper.renderer.overlay.polygon'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.polyline', \Ivory\GoogleMap\Helper\Subscriber\Overlay\PolylineSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.polyline'),
+            service('ivory.google_map.helper.renderer.overlay.polyline'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.rectangle', \Ivory\GoogleMap\Helper\Subscriber\Overlay\RectangleSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.rectangle'),
+            service('ivory.google_map.helper.renderer.overlay.rectangle'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.overlay.symbol', \Ivory\GoogleMap\Helper\Subscriber\Overlay\SymbolSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.overlay.symbol'),
+            service('ivory.google_map.helper.renderer.overlay.symbol'),
+        ])
+        ->tag('ivory.google_map.helper.map.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete', \Ivory\GoogleMap\Helper\Subscriber\Place\AutocompleteSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.place.autocomplete')])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete_container', \Ivory\GoogleMap\Helper\Subscriber\Place\AutocompleteContainerSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.place.autocomplete_container')])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete_html', \Ivory\GoogleMap\Helper\Subscriber\Place\AutocompleteHtmlSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.place.autocomplete_html')])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete_init', \Ivory\GoogleMap\Helper\Subscriber\Place\AutocompleteInitSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete_javascript', \Ivory\GoogleMap\Helper\Subscriber\Place\AutocompleteJavascriptSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.renderer.place.autocomplete'),
+            service('ivory.google_map.helper.renderer.utility.callback'),
+            service('ivory.google_map.helper.renderer.html.javascript_tag'),
+        ])
+        ->tag('ivory.google_map.helper.api.subscriber')
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.base', \Ivory\GoogleMap\Helper\Subscriber\Place\Base\AutocompleteBaseSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.base.bound', \Ivory\GoogleMap\Helper\Subscriber\Place\Base\AutocompleteBoundSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.place.autocomplete.base.bound'),
+            service('ivory.google_map.helper.renderer.base.bound'),
+        ])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.base.coordinate', \Ivory\GoogleMap\Helper\Subscriber\Place\Base\AutocompleteCoordinateSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.place.autocomplete.base.coordinate'),
+            service('ivory.google_map.helper.renderer.base.coordinate'),
+        ])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.event', \Ivory\GoogleMap\Helper\Subscriber\Place\Event\AutocompleteEventSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.event.dom_event', \Ivory\GoogleMap\Helper\Subscriber\Place\Event\AutocompleteDomEventSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.place.autocomplete.event.dom_event'),
+            service('ivory.google_map.helper.renderer.event.dom_event'),
+        ])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.event.dom_event_once', \Ivory\GoogleMap\Helper\Subscriber\Place\Event\AutocompleteDomEventOnceSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.place.autocomplete.event.dom_event_once'),
+            service('ivory.google_map.helper.renderer.event.dom_event_once'),
+        ])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.event.event', \Ivory\GoogleMap\Helper\Subscriber\Place\Event\AutocompleteSimpleEventSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.place.autocomplete.event.event'),
+            service('ivory.google_map.helper.renderer.event.event'),
+        ])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.place.autocomplete.event.event_once', \Ivory\GoogleMap\Helper\Subscriber\Place\Event\AutocompleteEventOnceSubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([
+            service('ivory.google_map.helper.collector.place.autocomplete.event.event_once'),
+            service('ivory.google_map.helper.renderer.event.event_once'),
+        ])
+        ->tag('ivory.google_map.helper.place_autocomplete.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static', \Ivory\GoogleMap\Helper\Subscriber\Image\StaticSubscriber::class)
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.center', \Ivory\GoogleMap\Helper\Subscriber\Image\CenterSubscriber::class)
+        ->args([service('ivory.google_map.helper.renderer.static.base.coordinate')])
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.encoded_polyline', \Ivory\GoogleMap\Helper\Subscriber\Image\EncodedPolylineSubscriber::class)
+        ->args([
+            service('ivory.google_map.helper.collector.static.encoded_polyline'),
+            service('ivory.google_map.helper.renderer.static.overlay.encoded_polyline'),
+        ])
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.extendable', \Ivory\GoogleMap\Helper\Subscriber\Image\ExtendableSubscriber::class)
+        ->args([
+            service('ivory.google_map.helper.collector.static.extendable'),
+            service('ivory.google_map.helper.renderer.static.overlay.extendable'),
+        ])
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.format', \Ivory\GoogleMap\Helper\Subscriber\Image\FormatSubscriber::class)
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.key', \Ivory\GoogleMap\Helper\Subscriber\Image\KeySubscriber::class)
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.marker', \Ivory\GoogleMap\Helper\Subscriber\Image\MarkerSubscriber::class)
+        ->args([
+            service('ivory.google_map.helper.collector.static.marker'),
+            service('ivory.google_map.helper.renderer.static.overlay.marker'),
+        ])
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.polyline', \Ivory\GoogleMap\Helper\Subscriber\Image\PolylineSubscriber::class)
+        ->args([
+            service('ivory.google_map.helper.collector.static.polyline'),
+            service('ivory.google_map.helper.renderer.static.overlay.polyline'),
+        ])
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.scale', \Ivory\GoogleMap\Helper\Subscriber\Image\ScaleSubscriber::class)
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.size', \Ivory\GoogleMap\Helper\Subscriber\Image\SizeSubscriber::class)
+        ->args([service('ivory.google_map.helper.renderer.static.size')])
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.type', \Ivory\GoogleMap\Helper\Subscriber\Image\TypeSubscriber::class)
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.static.zoom', \Ivory\GoogleMap\Helper\Subscriber\Image\ZoomSubscriber::class)
+        ->tag('ivory.google_map.helper.map.static.subscriber');
+
+    $services->set('ivory.google_map.helper.subscriber.utility.object_to_array', \Ivory\GoogleMap\Helper\Subscriber\Utility\ObjectToArraySubscriber::class)
+        ->parent('ivory.google_map.helper.subscriber.abstract')
+        ->args([service('ivory.google_map.helper.renderer.utility.object_to_array')])
+        ->tag('ivory.google_map.helper.map.subscriber');
+};

--- a/Resources/config/helper/utility.php
+++ b/Resources/config/helper/utility.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.helper.formatter', \Ivory\GoogleMap\Helper\Formatter\Formatter::class);
+
+    $services->set('ivory.google_map.helper.json_builder', \Ivory\GoogleMap\Helper\Builder\JsonBuilder::class);
+};

--- a/Resources/config/service/direction.php
+++ b/Resources/config/service/direction.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.direction', \Ivory\GoogleMap\Service\Direction\DirectionService::class);
+};

--- a/Resources/config/service/distance_matrix.php
+++ b/Resources/config/service/distance_matrix.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.distance_matrix', \Ivory\GoogleMap\Service\DistanceMatrix\DistanceMatrixService::class);
+};

--- a/Resources/config/service/elevation.php
+++ b/Resources/config/service/elevation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.elevation', \Ivory\GoogleMap\Service\Elevation\ElevationService::class);
+};

--- a/Resources/config/service/geocoder.php
+++ b/Resources/config/service/geocoder.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.geocoder', \Ivory\GoogleMap\Service\Geocoder\GeocoderService::class);
+};

--- a/Resources/config/service/place_autocomplete.php
+++ b/Resources/config/service/place_autocomplete.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.place_autocomplete', \Ivory\GoogleMap\Service\Place\Autocomplete\PlaceAutocompleteService::class);
+};

--- a/Resources/config/service/place_detail.php
+++ b/Resources/config/service/place_detail.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.place_detail', \Ivory\GoogleMap\Service\Place\Detail\PlaceDetailService::class);
+};

--- a/Resources/config/service/place_photo.php
+++ b/Resources/config/service/place_photo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.place_photo', \Ivory\GoogleMap\Service\Place\Photo\PlacePhotoService::class);
+};

--- a/Resources/config/service/place_search.php
+++ b/Resources/config/service/place_search.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.place_search', \Ivory\GoogleMap\Service\Place\Search\PlaceSearchService::class);
+};

--- a/Resources/config/service/time_zone.php
+++ b/Resources/config/service/time_zone.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.time_zone', \Ivory\GoogleMap\Service\TimeZone\TimeZoneService::class);
+};

--- a/Resources/config/twig.php
+++ b/Resources/config/twig.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('ivory.google_map.twig.extension.api', \Ivory\GoogleMapBundle\Twig\ApiExtension::class)
+        ->args([service('ivory.google_map.helper.api')])
+        ->tag('twig.extension');
+
+    $services->set('ivory.google_map.twig.extension.map', \Ivory\GoogleMapBundle\Twig\MapExtension::class)
+        ->args([service('ivory.google_map.helper.map')])
+        ->tag('twig.extension');
+
+    $services->set('ivory.google_map.twig.extension.map.static', \Ivory\GoogleMapBundle\Twig\StaticMapExtension::class)
+        ->args([service('ivory.google_map.helper.map.static')])
+        ->tag('twig.extension');
+
+    $services->set('ivory.google_map.twig.extension.place_autocomplete', \Ivory\GoogleMapBundle\Twig\PlaceAutocompleteExtension::class)
+        ->args([service('ivory.google_map.helper.place_autocomplete')])
+        ->tag('twig.extension');
+};

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -26,21 +26,19 @@ $ composer require ivory/google-map-bundle
 If you want to use the [Direction](/Resources/doc/service/direction.md), 
 [Distance Matrix](/Resources/doc/service/distance_matrix.md), [Elevation](/Resources/doc/service/elevation.md), 
 [Geocoder](/Resources/doc/service/geocoder.md), [Place](/Resources/doc/service/place/index.md) or 
-[Time Zone](/Resources/doc/service/time_zone.md) services, you will need an http client and message factory via 
-[Httplug](https://httplug.io/) which is an http client abstraction library as well as the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library. 
+[Time Zone](/Resources/doc/service/time_zone.md) services, you will need an [PSR-18](https://www.php-fig.org/psr/psr-18/) 
+http client and [PSR-17](https://www.php-fig.org/psr/psr-17/) request factory as well as the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
-[Httplug](https://httplug.io/) and [Ivory Serializer](https://github.com/egeloen/ivory-serializer) provide bundles, so 
-let's install them to ease our life:
+The simplest implementation of PSR compatible libraries is using Symfony's [HttpClient](https://github.com/symfony/http-client)
+and a lightweight [PSR-7 library](https://github.com/Nyholm/psr7) by [Tobias Nyholm](https://github.com/Nyholm).
+Next to that use the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) bundle, so let's install them to ease our life:
 
 ``` bash
 $ composer require egeloen/serializer-bundle
-$ composer require php-http/guzzle7-adapter
-$ composer require php-http/httplug-bundle
+$ composer require symfony/http-client
+$ composer require nyholm/psr7
 ```
-
-Here, I have chosen to use [Guzzle7](https://docs.guzzlephp.org/en/latest/psr7.html) but since Httplug supports the 
-most popular http clients, you can install your preferred one instead.
 
 ## Register the bundle
 
@@ -57,7 +55,14 @@ public function registerBundles()
         
         // Optionally
         new Ivory\SerializerBundle\IvorySerializerBundle(),
-        new Http\HttplugBundle\HttplugBundle(),
     ];
 }
 ```
+
+When using the [FrameworkBundle](https://github.com/symfony/framework-bundle) you will have a PSR-18 client service available 
+under `psr18.http_client`. Otherwise you would need to create a service definition for the 
+`Symfony\Component\HttpClient\Psr18Client` class and use that in the following Google service definitions in this bundle.
+
+The request factory implementation will be available as `nyholm.psr7.psr17_factory` when you use Symfony Flex in your 
+project. If not you must add a service definition for `Nyholm\Psr7\Factory\Psr17Factory` to be able to complete the 
+configuration.

--- a/Resources/doc/service/direction.md
+++ b/Resources/doc/service/direction.md
@@ -7,9 +7,9 @@ or as latitude/longitude coordinates. The Direction API can return multi-part di
 
 ## Dependencies
 
-The Direction API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library. 
+The Direction API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18 
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays. 
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library. 
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -21,26 +21,14 @@ By default, the direction service is disabled. In order to enable the service, y
 
 The http client and message factory are mandatory. They define which http client and message factory the direction 
 service will use for issuing http requests.
- 
-First, configure the [Httplug](http://httplug.io/) bundle.
 
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     direction:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        message_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/direction.md
+++ b/Resources/doc/service/direction.md
@@ -28,7 +28,7 @@ Configure the Google Map bundle:
 ivory_google_map:
     direction:
         client: psr18.http_client
-        message_factory: nyholm.psr7.psr17_factory
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/distance_matrix.md
+++ b/Resources/doc/service/distance_matrix.md
@@ -9,9 +9,9 @@ single origin and destination to the [Direction API](/Resources/doc/service/dire
 
 ## Dependencies
 
-The Distance Matrix API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
+The Distance Matrix API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -24,25 +24,13 @@ By default, the distance matrix service is disabled. In order to enable the serv
 The http client and message factory are mandatory. They define which http client and message factory the distance 
 matrix service will use for issuing http requests.
  
-First, configure the [Httplug](http://httplug.io/) bundle.
-
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     distance_matrix:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/elevation.md
+++ b/Resources/doc/service/elevation.md
@@ -6,9 +6,9 @@ routes.
 
 ## Dependencies
 
-The Elevation API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
+The Elevation API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -21,25 +21,13 @@ By default, the elevation service is disabled. In order to enable the service, y
 The http client and message factory are mandatory. They define which http client and message factory the direction 
 service will use for issuing http requests.
  
-First, configure the [Httplug](http://httplug.io/) bundle.
-
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     elevation:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/geocoder.md
+++ b/Resources/doc/service/geocoder.md
@@ -7,9 +7,9 @@ process is known as "reverse geocoding".
 
 ## Dependencies
 
-The Geocoder API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
+The Geocoder API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -22,25 +22,13 @@ By default, the geocoder service is disabled. In order to enable the service, yo
 The http client and message factory are mandatory. They define which http client and message factory the geocoder 
 service will use for issuing http requests.
  
-First, configure the [Httplug](http://httplug.io/) bundle.
-
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     geocoder:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/place/autocomplete.md
+++ b/Resources/doc/service/place/autocomplete.md
@@ -33,7 +33,7 @@ Configure the Google Map bundle:
 ivory_google_map:
     place_autocomplete:
         client: psr18.http_client
-        message_factory: nyholm.psr7.psr17_factory
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/place/autocomplete.md
+++ b/Resources/doc/service/place/autocomplete.md
@@ -12,9 +12,9 @@ request for more information about any of the places which are returned.
 
 ## Dependencies
 
-The Place Autocomplete API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library. 
+The Place Autocomplete API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -25,27 +25,15 @@ By default, the place autocomplete service is disabled. In order to enable the s
 ### Http client and message factory
 
 The http client and message factory are mandatory. They define which http client and message factory the place 
-autocomplete service will use for issuing http requests.
- 
-First, configure the [Httplug](http://httplug.io/) bundle.
+autocomplete service will use for issuing http requests. Here we use `symfony/http-client` and `nyholm/psr7`.
 
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        message_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/place/detail.md
+++ b/Resources/doc/service/place/detail.md
@@ -28,7 +28,7 @@ Configure the Google Map bundle:
 ivory_google_map:
     place_detail:
         client: psr18.http_client
-        message_factory: nyholm.psr7.psr17_factory
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/place/detail.md
+++ b/Resources/doc/service/place/detail.md
@@ -7,9 +7,9 @@ its complete address, phone number, user rating and reviews.
 
 ## Dependencies
 
-The Place Detail API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library. 
+The Place Detail API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -20,27 +20,15 @@ By default, the place detail service is disabled. In order to enable the service
 ### Http client and message factory
 
 The http client and message factory are mandatory. They define which http client and message factory the place 
-detail service will use for issuing http requests.
- 
-First, configure the [Httplug](http://httplug.io/) bundle.
+detail service will use for issuing http requests. Here we use `symfony/http-client` and `nyholm/psr7`.
 
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     place_detail:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        message_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/place/search.md
+++ b/Resources/doc/service/place/search.md
@@ -6,9 +6,9 @@ proximity or a text string. A Place Search returns a list of places along with s
 
 ## Dependencies
 
-The Place Autocomplete API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library. 
+The Place Search API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -19,27 +19,15 @@ By default, the place search service is disabled. In order to enable the service
 ### Http client and message factory
 
 The http client and message factory are mandatory. They define which http client and message factory the place 
-search service will use for issuing http requests.
+search service will use for issuing http requests. Here we use `symfony/http-client` and `nyholm/psr7`.
  
-First, configure the [Httplug](http://httplug.io/) bundle.
-
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     place_search:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Resources/doc/service/time_zone.md
+++ b/Resources/doc/service/time_zone.md
@@ -5,9 +5,9 @@ as that location's time offset from UTC.
 
 ## Dependencies
 
-The Time Zone API requires an http client and a serializer. The library relies respectively on 
-[Httplug](http://httplug.io/) which is an http client abstraction library and the 
-[Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
+The Time Zone API requires an [PSR-18](https://www.php-fig.org/psr/psr-18/) http client and a serializer. Any PSR-18
+http client library is suitable, [HttpClient](https://github.com/symfony/http-client) is a popular and steady choice nowadays.
+And the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) which is an advanced (de)-serialization library.
 
 To install them, read this [documentation](/Resources/doc/installation.md).
 
@@ -20,25 +20,13 @@ By default, the time zone service is disabled. In order to enable the service, y
 The http client and message factory are mandatory. They define which http client and message factory the time zone 
 service will use for issuing http requests.
  
-First, configure the [Httplug](http://httplug.io/) bundle.
-
-``` yaml
-httplug:
-    classes:
-        client: Http\Adapter\Guzzle7\Client
-        message_factory: Http\Message\MessageFactory\GuzzleMessageFactory
-    clients:
-        acme:
-            factory: httplug.factory.guzzle7
-```
-
-Then, configure the Google Map bundle:
+Configure the Google Map bundle:
 
 ``` yaml
 ivory_google_map:
     time_zone:
-        client: httplug.client.default
-        message_factory: httplug.message_factory.default
+        client: psr18.http_client
+        request_factory: nyholm.psr7.psr17_factory
 ```
 
 ### Format

--- a/Tests/DependencyInjection/AbstractIvoryGoogleMapExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractIvoryGoogleMapExtensionTest.php
@@ -11,8 +11,6 @@
 
 namespace Ivory\GoogleMapBundle\Tests\DependencyInjection;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Helper\ApiHelper;
 use Ivory\GoogleMap\Helper\MapHelper;
 use Ivory\GoogleMap\Helper\PlaceAutocompleteHelper;
@@ -30,6 +28,8 @@ use Ivory\GoogleMapBundle\DependencyInjection\IvoryGoogleMapExtension;
 use Ivory\GoogleMapBundle\IvoryGoogleMapBundle;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -55,14 +55,14 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
     private $locale;
 
     /**
-     * @var HttpClient|MockObject
+     * @var ClientInterface|MockObject
      */
     private $client;
 
     /**
-     * @var MessageFactory|MockObject
+     * @var RequestFactoryInterface|MockObject
      */
-    private $messageFactory;
+    private $requestFactory;
 
     /**
      * {@inheritdoc}
@@ -74,8 +74,8 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
         $this->container->setParameter('kernel.project_dir', realpath(__DIR__.'/../..'));
         $this->container->setParameter('kernel.debug', $this->debug = false);
         $this->container->setParameter('locale', $this->locale = 'en');
-        $this->container->set('httplug.client', $this->client = $this->createClientMock());
-        $this->container->set('httplug.message_factory', $this->messageFactory = $this->createMessageFactoryMock());
+        $this->container->set('http_client', $this->client = $this->createClientMock());
+        $this->container->set('http_request_factory', $this->requestFactory = $this->creatRequestFactoryMock());
         $this->container->registerExtension($extension = new IvoryGoogleMapExtension());
         $this->container->loadFromExtension($extension->getAlias());
         (new IvoryGoogleMapBundle())->build($this->container);
@@ -253,7 +253,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(DirectionService::class, $direction);
         $this->assertSame($this->client, $direction->getClient());
-        $this->assertSame($this->messageFactory, $direction->getMessageFactory());
+        $this->assertSame($this->requestFactory, $direction->getRequestFactory());
         $this->assertFalse($direction->hasBusinessAccount());
 
         # TODO Check
@@ -317,7 +317,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(DistanceMatrixService::class, $distanceMatrix);
         $this->assertSame($this->client, $distanceMatrix->getClient());
-        $this->assertSame($this->messageFactory, $distanceMatrix->getMessageFactory());
+        $this->assertSame($this->requestFactory, $distanceMatrix->getRequestFactory());
         $this->assertFalse($distanceMatrix->hasBusinessAccount());
     }
 
@@ -378,7 +378,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(ElevationService::class, $elevation);
         $this->assertSame($this->client, $elevation->getClient());
-        $this->assertSame($this->messageFactory, $elevation->getMessageFactory());
+        $this->assertSame($this->requestFactory, $elevation->getRequestFactory());
         $this->assertFalse($elevation->hasBusinessAccount());
     }
 
@@ -439,7 +439,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(GeocoderService::class, $geocoder);
         $this->assertSame($this->client, $geocoder->getClient());
-        $this->assertSame($this->messageFactory, $geocoder->getMessageFactory());
+        $this->assertSame($this->requestFactory, $geocoder->getRequestFactory());
         $this->assertFalse($geocoder->hasBusinessAccount());
     }
 
@@ -500,7 +500,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(PlaceAutocompleteService::class, $placeAutocomplete);
         $this->assertSame($this->client, $placeAutocomplete->getClient());
-        $this->assertSame($this->messageFactory, $placeAutocomplete->getMessageFactory());
+        $this->assertSame($this->requestFactory, $placeAutocomplete->getRequestFactory());
         $this->assertFalse($placeAutocomplete->hasBusinessAccount());
     }
 
@@ -561,7 +561,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(PlaceDetailService::class, $placeDetail);
         $this->assertSame($this->client, $placeDetail->getClient());
-        $this->assertSame($this->messageFactory, $placeDetail->getMessageFactory());
+        $this->assertSame($this->requestFactory, $placeDetail->getRequestFactory());
         $this->assertFalse($placeDetail->hasBusinessAccount());
     }
 
@@ -675,7 +675,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(PlaceSearchService::class, $placeSearch);
         $this->assertSame($this->client, $placeSearch->getClient());
-        $this->assertSame($this->messageFactory, $placeSearch->getMessageFactory());
+        $this->assertSame($this->requestFactory, $placeSearch->getRequestFactory());
         $this->assertFalse($placeSearch->hasBusinessAccount());
     }
 
@@ -736,7 +736,7 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
 
         $this->assertInstanceOf(TimeZoneService::class, $timeZone);
         $this->assertSame($this->client, $timeZone->getClient());
-        $this->assertSame($this->messageFactory, $timeZone->getMessageFactory());
+        $this->assertSame($this->requestFactory, $timeZone->getRequestFactory());
         $this->assertFalse($timeZone->hasBusinessAccount());
     }
 
@@ -796,26 +796,17 @@ abstract class AbstractIvoryGoogleMapExtensionTest extends TestCase
         $this->container->compile();
     }
 
-    /**
-     * @return MockObject|HttpClient
-     */
-    private function createClientMock()
+    private function createClientMock(): MockObject|ClientInterface
     {
-        return $this->createMock(HttpClient::class);
+        return $this->createMock(ClientInterface::class);
     }
 
-    /**
-     * @return MockObject|MessageFactory
-     */
-    private function createMessageFactoryMock()
+    private function creatRequestFactoryMock(): RequestFactoryInterface|MockObject
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(RequestFactoryInterface::class);
     }
 
-    /**
-     * @return MockObject|SerializerInterface
-     */
-    private function createSerializerMock()
+    private function createSerializerMock(): SerializerInterface|MockObject
     {
         return $this->createMock(SerializerInterface::class);
     }

--- a/Tests/Fixtures/Config/Yaml/direction.yml
+++ b/Tests/Fixtures/Config/Yaml/direction.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     direction:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/direction_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/direction_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     direction:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/direction_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/direction_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     direction:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/direction_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/direction_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     direction:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/direction_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/direction_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     direction:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/direction_format.yml
+++ b/Tests/Fixtures/Config/Yaml/direction_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     direction:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/distance_matrix.yml
+++ b/Tests/Fixtures/Config/Yaml/distance_matrix.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     distance_matrix:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/distance_matrix_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/distance_matrix_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     distance_matrix:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/distance_matrix_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/distance_matrix_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     distance_matrix:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/distance_matrix_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/distance_matrix_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     distance_matrix:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/distance_matrix_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/distance_matrix_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     distance_matrix:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/distance_matrix_format.yml
+++ b/Tests/Fixtures/Config/Yaml/distance_matrix_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     distance_matrix:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/elevation.yml
+++ b/Tests/Fixtures/Config/Yaml/elevation.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     elevation:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/elevation_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/elevation_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     elevation:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/elevation_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/elevation_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     elevation:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/elevation_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/elevation_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     elevation:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/elevation_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/elevation_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     elevation:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/elevation_format.yml
+++ b/Tests/Fixtures/Config/Yaml/elevation_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     elevation:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/geocoder.yml
+++ b/Tests/Fixtures/Config/Yaml/geocoder.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     geocoder:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/geocoder_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/geocoder_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     geocoder:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/geocoder_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/geocoder_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     geocoder:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/geocoder_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/geocoder_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     geocoder:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/geocoder_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/geocoder_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     geocoder:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/geocoder_format.yml
+++ b/Tests/Fixtures/Config/Yaml/geocoder_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     geocoder:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/place_autocomplete.yml
+++ b/Tests/Fixtures/Config/Yaml/place_autocomplete.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/place_autocomplete_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/place_autocomplete_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/place_autocomplete_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/place_autocomplete_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/place_autocomplete_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/place_autocomplete_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/place_autocomplete_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/place_autocomplete_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/place_autocomplete_format.yml
+++ b/Tests/Fixtures/Config/Yaml/place_autocomplete_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_autocomplete:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/place_detail.yml
+++ b/Tests/Fixtures/Config/Yaml/place_detail.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     place_detail:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/place_detail_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/place_detail_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_detail:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/place_detail_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/place_detail_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     place_detail:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/place_detail_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/place_detail_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     place_detail:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/place_detail_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/place_detail_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_detail:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/place_detail_format.yml
+++ b/Tests/Fixtures/Config/Yaml/place_detail_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_detail:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/place_search.yml
+++ b/Tests/Fixtures/Config/Yaml/place_search.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     place_search:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/place_search_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/place_search_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_search:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/place_search_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/place_search_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     place_search:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/place_search_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/place_search_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     place_search:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/place_search_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/place_search_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_search:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/place_search_format.yml
+++ b/Tests/Fixtures/Config/Yaml/place_search_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     place_search:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/Tests/Fixtures/Config/Yaml/time_zone.yml
+++ b/Tests/Fixtures/Config/Yaml/time_zone.yml
@@ -7,5 +7,5 @@
 
 ivory_google_map:
     time_zone:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory

--- a/Tests/Fixtures/Config/Yaml/time_zone_api_key.yml
+++ b/Tests/Fixtures/Config/Yaml/time_zone_api_key.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     time_zone:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         api_key: key

--- a/Tests/Fixtures/Config/Yaml/time_zone_business_account.yml
+++ b/Tests/Fixtures/Config/Yaml/time_zone_business_account.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     time_zone:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/time_zone_business_account_channel.yml
+++ b/Tests/Fixtures/Config/Yaml/time_zone_business_account_channel.yml
@@ -7,8 +7,8 @@
 
 ivory_google_map:
     time_zone:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account:
             client_id: my-client
             secret: my-secret

--- a/Tests/Fixtures/Config/Yaml/time_zone_business_account_invalid.yml
+++ b/Tests/Fixtures/Config/Yaml/time_zone_business_account_invalid.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     time_zone:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         business_account: ~

--- a/Tests/Fixtures/Config/Yaml/time_zone_format.yml
+++ b/Tests/Fixtures/Config/Yaml/time_zone_format.yml
@@ -7,6 +7,6 @@
 
 ivory_google_map:
     time_zone:
-        client: httplug.client
-        message_factory: httplug.message_factory
+        client: http_client
+        request_factory: http_request_factory
         format: xml

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,23 @@
     "require": {
         "php": "^8.1",
         "symfony/framework-bundle": "^6.4 || ^7.0",
-        "ivory/google-map": "^6.0.1"
+        "ivory/google-map": "psr-refactor-dev"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.49",
         "php-http/cache-plugin": "^2.0",
-        "php-http/guzzle7-adapter": "^1.0",
         "phpunit/phpunit": "^9.6",
         "phpunit/phpunit-selenium": "^9.0",
         "symfony/cache": "^6.4 || ^7.0",
+        "symfony/http-client": "^6.4 || ^7.0",
         "symfony/form": "^6.4 || ^7.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/yaml": "^6.4 || ^7.0",
-        "twig/twig": "^3.8"
+        "twig/twig": "^3.8",
+        "nyholm/psr7": "^1.8"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit -c phpunit.ci.xml"
     },
     "autoload": {
         "psr-4": { "Ivory\\GoogleMapBundle\\": "" }
@@ -41,5 +45,11 @@
     },
     "replace": {
         "egeloen/google-map-bundle": "^3.0.1"
-    }
+    },
+    "repositories": [
+        {
+          "type": "vcs",
+          "url": "git@github.com:evertharmeling/ivory-google-map.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "phpunit/phpunit": "^9.6",
         "phpunit/phpunit-selenium": "^9.0",
         "symfony/cache": "^6.4 || ^7.3",
+        "symfony/dependency-injection": "^6.4 || ^7.3",
         "symfony/http-client": "^6.4 || ^7.3",
         "symfony/form": "^6.4 || ^7.3",
         "symfony/phpunit-bridge": "^6.4 || ^7.3",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/framework-bundle": "^6.4 || ^7.3",
+        "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0",
         "ivory/google-map": "psr-refactor-dev"
     },
     "require-dev": {
@@ -26,12 +26,12 @@
         "php-http/cache-plugin": "^2.0",
         "phpunit/phpunit": "^9.6",
         "phpunit/phpunit-selenium": "^9.0",
-        "symfony/cache": "^6.4 || ^7.3",
-        "symfony/dependency-injection": "^6.4 || ^7.3",
-        "symfony/http-client": "^6.4 || ^7.3",
-        "symfony/form": "^6.4 || ^7.3",
-        "symfony/phpunit-bridge": "^6.4 || ^7.3",
-        "symfony/yaml": "^6.4 || ^7.3",
+        "symfony/cache": "^6.4 || ^7.4 || ^8.0",
+        "symfony/dependency-injection": "^6.4 || ^7.4 || ^8.0",
+        "symfony/http-client": "^6.4 || ^7.4 || ^8.0",
+        "symfony/form": "^6.4 || ^7.4 || ^8.0",
+        "symfony/phpunit-bridge": "^6.4 || ^7.4 || ^8.0",
+        "symfony/yaml": "^6.4 || ^7.4 || ^8.0",
         "twig/twig": "^3.8",
         "nyholm/psr7": "^1.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
+        "symfony/framework-bundle": "^6.4 || ^7.3",
         "ivory/google-map": "psr-refactor-dev"
     },
     "require-dev": {
@@ -26,11 +26,11 @@
         "php-http/cache-plugin": "^2.0",
         "phpunit/phpunit": "^9.6",
         "phpunit/phpunit-selenium": "^9.0",
-        "symfony/cache": "^6.4 || ^7.0",
-        "symfony/http-client": "^6.4 || ^7.0",
-        "symfony/form": "^6.4 || ^7.0",
-        "symfony/phpunit-bridge": "^6.4 || ^7.0",
-        "symfony/yaml": "^6.4 || ^7.0",
+        "symfony/cache": "^6.4 || ^7.3",
+        "symfony/http-client": "^6.4 || ^7.3",
+        "symfony/form": "^6.4 || ^7.3",
+        "symfony/phpunit-bridge": "^6.4 || ^7.3",
+        "symfony/yaml": "^6.4 || ^7.3",
         "twig/twig": "^3.8",
         "nyholm/psr7": "^1.8"
     },

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -11,6 +11,7 @@
     </testsuites>
 
     <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
         <server name="BROWSER_NAME" value="chrome" />
         <server name="SELENIUM_HOST" value="selenium-chrome" />
         <server name="CACHE_PATH" value="Tests/.cache" />


### PR DESCRIPTION
Changes after not relying on the `php-http/message-factory` package within `ivory/google-map` anymore:
- Replaced `Http\Message\MessageFactory` with `Psr\Http\Message\RequestFactoryInterface`
- Replaced `Http\Client\HttpClient` with `Psr\Http\Client\ClientInterface`
- Dropped references to [Httplug](https://httplug.io/) as it's not needed anymore with full PSR-17 and PSR-18 compatibility, also simplifies configuration.

*Todo*
- [x] Update docs
- [ ] Update `ivory/google-map` version requirement after new release

*Blocked by https://github.com/bresam/ivory-google-map/pull/45*